### PR TITLE
Add version number

### DIFF
--- a/simple-tree-text-markup-doc/info.rkt
+++ b/simple-tree-text-markup-doc/info.rkt
@@ -12,6 +12,7 @@
                      "gui-doc"
                      "snip-lib"))
 (define deps '("base"))
+(define update-implies '("simple-tree-text-markup-lib"))
 
 (define pkg-desc "documentation part of \"simple-tree-text-markup\"")
 

--- a/simple-tree-text-markup-lib/info.rkt
+++ b/simple-tree-text-markup-lib/info.rkt
@@ -8,3 +8,5 @@
 (define pkg-desc "Simple tree-based markup representation for use in the REPL")
 
 (define pkg-authors '(sperber))
+
+(define version "1.0")

--- a/simple-tree-text-markup-lib/info.rkt
+++ b/simple-tree-text-markup-lib/info.rkt
@@ -9,4 +9,4 @@
 
 (define pkg-authors '(sperber))
 
-(define version "1.0")
+(define version "1.1")


### PR DESCRIPTION
`htdp-lib` introduced a new dependency (https://github.com/racket/htdp/commit/ea863c346da00a9b8f2d947af1039cf76353bdb7) on the latest `simple-tree-text-markup-lib` (https://github.com/racket/simple-tree-text-markup/commit/aeaa9b1a37a3d0f1e1b11f49a2b97c3a3cb6ca16). By adding a version number, `htdp-lib` can correctly specify this dependency.